### PR TITLE
Fix automation modes for motion-activated lights

### DIFF
--- a/homeassistant/config/automations/lights/turn_off_entrance_ambient_lights_when_no_motion_is_detected.yaml
+++ b/homeassistant/config/automations/lights/turn_off_entrance_ambient_lights_when_no_motion_is_detected.yaml
@@ -1,7 +1,7 @@
 id: turn_off_entrance_ambient_light_when_no_motion_is_detected
 alias: Turn off Entrance Ambient Lights if no motion is detected
 description: ""
-mode: single
+mode: restart
 actions:
   - alias: Turn off lights
     parallel:

--- a/homeassistant/config/automations/lights/turn_off_office_leds_if_no_motion_detected.yaml
+++ b/homeassistant/config/automations/lights/turn_off_office_leds_if_no_motion_detected.yaml
@@ -1,7 +1,7 @@
 id: turn_off_office_leds_if_no_motion_detected
 alias: Turn off Office LEDs if no motion is detected
 description: ""
-mode: single
+mode: restart
 trigger:
   - platform: state
     entity_id:

--- a/homeassistant/config/automations/lights/turn_on_entrance_ambient_lights_when_motion_is_detected.yaml
+++ b/homeassistant/config/automations/lights/turn_on_entrance_ambient_lights_when_motion_is_detected.yaml
@@ -1,7 +1,7 @@
 id: turn_on_entrance_ambient_lights_when_motion_is_detected
 alias: Turn on entrance ambient lights if motion is detected
 description: ""
-mode: single
+mode: restart
 triggers:
   - trigger: state
     entity_id:

--- a/homeassistant/config/automations/lights/turn_on_office_leds_if_motion_detected.yaml
+++ b/homeassistant/config/automations/lights/turn_on_office_leds_if_motion_detected.yaml
@@ -1,7 +1,7 @@
 id: turn_on_office_leds_if_motion_detected
 alias: Turn on Office LEDs if motion is detected
 description: ""
-mode: single
+mode: restart
 trigger:
   - platform: state
     entity_id:


### PR DESCRIPTION
Change mode from 'single' to 'restart' for motion-activated light automations. This ensures re-triggers reset the timer, keeping lights on while motion continues.

With mode: single, re-triggers are ignored while running, so motion lights wouldn't properly extend their on-time.